### PR TITLE
Fix JEI/Mek invisible fluid bug

### DIFF
--- a/src/main/java/com/smashingmods/chemlib/api/Chemical.java
+++ b/src/main/java/com/smashingmods/chemlib/api/Chemical.java
@@ -3,20 +3,14 @@ package com.smashingmods.chemlib.api;
 import com.smashingmods.chemlib.registry.FluidRegistry;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
-import com.smashingmods.chemlib.registry.FluidRegistry;
-import net.minecraft.core.Registry;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.level.ItemLike;
-import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.Optional;
 import net.minecraftforge.fluids.FluidType;
-import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface Chemical extends ItemLike {
 

--- a/src/main/java/com/smashingmods/chemlib/common/items/CompoundItem.java
+++ b/src/main/java/com/smashingmods/chemlib/common/items/CompoundItem.java
@@ -35,7 +35,7 @@ public class CompoundItem extends Item implements Compound {
         this.matterState = pMatterState;
         this.components = pComponents;
         this.description = pDescription;
-        this.color = (int) Long.parseLong(pColor, 16);
+        this.color = Integer.parseInt(pColor, 16) | 0xFF000000;
         this.effects = pEffects;
     }
 

--- a/src/main/java/com/smashingmods/chemlib/common/items/ElementItem.java
+++ b/src/main/java/com/smashingmods/chemlib/common/items/ElementItem.java
@@ -46,7 +46,7 @@ public class ElementItem extends Item implements Element {
         this.matterState = pMatterState;
         this.metalType = pMetalType;
         this.artificial = pArtificial;
-        this.color = (int) Long.parseLong(pColor, 16);
+        this.color = Integer.parseInt(pColor, 16) | 0xFF000000;
         this.effects = pEffects;
     }
 

--- a/src/main/java/com/smashingmods/chemlib/registry/ChemicalRegistry.java
+++ b/src/main/java/com/smashingmods/chemlib/registry/ChemicalRegistry.java
@@ -81,7 +81,7 @@ public class ChemicalRegistry {
                                 BlockRegistry.BLOCKS.register(String.format("%s_lamp_block", elementName), () -> new LampBlock(new ResourceLocation(ChemLib.MODID, elementName), ChemicalBlockType.LAMP, BlockRegistry.LAMP_BLOCKS, BlockRegistry.LAMP_PROPERTIES));
                                 BlockRegistry.getRegistryObjectByName(String.format("%s_lamp_block", elementName)).ifPresent(block -> ItemRegistry.fromChemicalBlock(block, new Item.Properties().tab(ItemRegistry.MISC_TAB)));
                             }
-                            FluidRegistry.registerFluid(elementName, fluidTypePropertiesFactory(properties, elementName), (int) Long.parseLong(color, 16), slopeFindDistance, decreasePerBlock);
+                            FluidRegistry.registerFluid(elementName, fluidTypePropertiesFactory(properties, elementName), (int) Long.parseLong("FF" + color, 16), slopeFindDistance, decreasePerBlock);
                         }
                     }
                 }
@@ -131,7 +131,7 @@ public class ChemicalRegistry {
                         int decreasePerBlock = properties.has("decrease_per_block") ? properties.get("decrease_per_block").getAsInt() : 1;
 
                         switch (matterState) {
-                            case LIQUID, GAS -> FluidRegistry.registerFluid(compoundName, fluidTypePropertiesFactory(properties, compoundName), (int) Long.parseLong(color, 16), slopeFindDistance, decreasePerBlock);
+                            case LIQUID, GAS -> FluidRegistry.registerFluid(compoundName, fluidTypePropertiesFactory(properties, compoundName), (int) Long.parseLong("FF" + color, 16), slopeFindDistance, decreasePerBlock);
                         }
                     }
                 }

--- a/src/main/java/com/smashingmods/chemlib/registry/ChemicalRegistry.java
+++ b/src/main/java/com/smashingmods/chemlib/registry/ChemicalRegistry.java
@@ -81,7 +81,7 @@ public class ChemicalRegistry {
                                 BlockRegistry.BLOCKS.register(String.format("%s_lamp_block", elementName), () -> new LampBlock(new ResourceLocation(ChemLib.MODID, elementName), ChemicalBlockType.LAMP, BlockRegistry.LAMP_BLOCKS, BlockRegistry.LAMP_PROPERTIES));
                                 BlockRegistry.getRegistryObjectByName(String.format("%s_lamp_block", elementName)).ifPresent(block -> ItemRegistry.fromChemicalBlock(block, new Item.Properties().tab(ItemRegistry.MISC_TAB)));
                             }
-                            FluidRegistry.registerFluid(elementName, fluidTypePropertiesFactory(properties, elementName), (int) Long.parseLong("FF" + color, 16), slopeFindDistance, decreasePerBlock);
+                            FluidRegistry.registerFluid(elementName, fluidTypePropertiesFactory(properties, elementName), Integer.parseInt(color, 16) | 0xFF000000, slopeFindDistance, decreasePerBlock);
                         }
                     }
                 }
@@ -131,7 +131,7 @@ public class ChemicalRegistry {
                         int decreasePerBlock = properties.has("decrease_per_block") ? properties.get("decrease_per_block").getAsInt() : 1;
 
                         switch (matterState) {
-                            case LIQUID, GAS -> FluidRegistry.registerFluid(compoundName, fluidTypePropertiesFactory(properties, compoundName), (int) Long.parseLong("FF" + color, 16), slopeFindDistance, decreasePerBlock);
+                            case LIQUID, GAS -> FluidRegistry.registerFluid(compoundName, fluidTypePropertiesFactory(properties, compoundName), Integer.parseInt(color, 16) | 0xFF000000, slopeFindDistance, decreasePerBlock);
                         }
                     }
                 }


### PR DESCRIPTION
JSON objects for elements and compounds were passing alpha, so adding the string "FF" + color into the dynamic fluid registry resulted in removing the alpha pass to the fluids giving us our proper fluid color.
We discussed why "FF" was not already defined in the color codes in the .json, so I am avoiding changing anything other than just the fluids to respect such a thing.

Thank you!